### PR TITLE
Feature/1340 bindable span

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/LabelCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/LabelCoreGalleryPage.cs
@@ -43,9 +43,9 @@ namespace Xamarin.Forms.Controls
 #pragma warning restore 618
 
 			var formattedString = new FormattedString ();
-			formattedString.Spans.Add (new Span { BackgroundColor = Color.Red, ForegroundColor = Color.Olive, Text = "Span 1 " });
-			formattedString.Spans.Add (new Span { BackgroundColor = Color.Black, ForegroundColor = Color.White, Text = "Span 2 " });
-			formattedString.Spans.Add (new Span { BackgroundColor = Color.Pink, ForegroundColor = Color.Purple, Text = "Span 3" });
+			formattedString.Spans.Add (new Span { BackgroundColor = Color.Red, TextColor = Color.Olive, Text = "Span 1 " });
+			formattedString.Spans.Add (new Span { BackgroundColor = Color.Black, TextColor = Color.White, Text = "Span 2 " });
+			formattedString.Spans.Add (new Span { BackgroundColor = Color.Pink, TextColor = Color.Purple, Text = "Span 3" });
 
 			var formattedTextContainer = new ViewContainer<Label> (Test.Label.FormattedText, new Label { FormattedText = formattedString });
 

--- a/Xamarin.Forms.Controls/GalleryPages/LabelGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/LabelGallery.cs
@@ -37,10 +37,10 @@ namespace Xamarin.Forms.Controls
 			var formatted = new Label { FormattedText = new FormattedString { 
 					Spans = { 
 #pragma warning disable 618
-						new Span {Text="FormattedStrings ", ForegroundColor=Color.Blue, BackgroundColor = Color.Yellow, Font = Font.BoldSystemFontOfSize (NamedSize.Large)},
+						new Span {Text="FormattedStrings ", TextColor=Color.Blue, BackgroundColor = Color.Yellow, Font = Font.BoldSystemFontOfSize (NamedSize.Large)},
 #pragma warning restore 618
-						new Span {Text="are ", ForegroundColor=Color.Red, BackgroundColor = Color.Gray},
-						new Span {Text="not pretty!", ForegroundColor = Color.Green,},
+						new Span {Text="are ", TextColor=Color.Red, BackgroundColor = Color.Gray},
+						new Span {Text="not pretty!", TextColor = Color.Green,},
 					}
 				} };
 			var missingfont = new Label { Text = "Missing font: use default" };

--- a/Xamarin.Forms.Core.UnitTests/SpanTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/SpanTests.cs
@@ -1,0 +1,86 @@
+﻿using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class SpanTests : BaseTestFixture
+	{
+		[SetUp]
+		public override void Setup()
+		{
+			base.Setup();
+			Device.PlatformServices = new MockPlatformServices();
+		}
+
+		[TearDown]
+		public override void TearDown()
+		{
+			base.TearDown();
+			Device.PlatformServices = null;
+		}
+
+		[Test]
+		public void StyleApplied()
+		{
+			var pinkStyle = new Style(typeof(Span))
+			{
+				Setters = {
+					new Setter { Property = Span.TextColorProperty, Value = Color.Pink },
+				},
+				Class = "pink",
+				ApplyToDerivedTypes = true,
+			};
+
+			var span = new Span
+			{
+				Style = pinkStyle
+			};
+
+			var formattedText = new FormattedString();
+			formattedText.Spans.Add(span);
+
+			var label = new Label()
+			{
+				FormattedText = formattedText
+			};
+
+			new ContentView
+			{
+				Resources = new ResourceDictionary { pinkStyle },
+				Content = label
+			};
+
+			Assert.AreEqual(Color.Pink, span.TextColor);
+		}
+
+		[Test]
+		public void BindingApplied()
+		{
+			var vm = new ViewModel()
+			{
+				Text = "CheckBindingWorked"
+			};
+
+			var formattedText = new FormattedString();
+
+			var label = new Label()
+			{
+				FormattedText = formattedText
+			};
+
+			var span = new Span();
+			span.SetBinding(Span.TextProperty, "Text");
+
+			formattedText.Spans.Add(span);
+
+			label.BindingContext = vm;
+
+			Assert.AreEqual(vm.Text, span.Text);
+		}
+
+		class ViewModel
+		{
+			public string Text { get; set; }
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="FlowDirectionTests.cs" />
     <Compile Include="LayoutChildIntoBoundingRegionTests.cs" />
     <Compile Include="MenuUnitTests.cs" />
+    <Compile Include="SpanTests.cs" />
     <Compile Include="TemplatedViewUnitTests.cs" />
     <Compile Include="TemplatedPageUnitTests.cs" />
     <Compile Include="ContentFormUnitTests.cs" />
@@ -217,8 +218,5 @@
     <EmbeddedResource Include="Images\crimson.jpg">
       <LogicalName>Images/crimson.jpg</LogicalName>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="StyleSheets\" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core/FormattedString.cs
+++ b/Xamarin.Forms.Core/FormattedString.cs
@@ -14,12 +14,12 @@ namespace Xamarin.Forms
 
 		public FormattedString()
 		{
-			_spans.CollectionChanged += OnCollectionChanged;			
-			BindingContextChanged += FormattedString_BindingContextChanged;
+			_spans.CollectionChanged += OnCollectionChanged;
 		}
 
-		private void FormattedString_BindingContextChanged(object sender, EventArgs e)
+		protected override void OnBindingContextChanged()
 		{
+			base.OnBindingContextChanged();
 			for (int i = 0; i < Spans.Count; i++)
 				SetInheritedBindingContext(Spans[i], BindingContext);
 		}

--- a/Xamarin.Forms.Core/FormattedString.cs
+++ b/Xamarin.Forms.Core/FormattedString.cs
@@ -20,8 +20,8 @@ namespace Xamarin.Forms
 
 		private void FormattedString_BindingContextChanged(object sender, EventArgs e)
 		{
-			foreach (var span in Spans)
-				SetInheritedBindingContext(span, BindingContext);
+			for (int i = 0; i < Spans.Count; i++)
+				SetInheritedBindingContext(Spans[i], BindingContext);
 		}
 
 		public IList<Span> Spans
@@ -51,6 +51,7 @@ namespace Xamarin.Forms
 				foreach (object item in e.OldItems)
 				{
 					var bo = item as Span;
+					SetInheritedBindingContext(bo, null);
 					if (bo != null)
 						bo.PropertyChanged -= OnItemPropertyChanged;
 				}

--- a/Xamarin.Forms.Core/FormattedString.cs
+++ b/Xamarin.Forms.Core/FormattedString.cs
@@ -4,27 +4,31 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms
 {
 	[ContentProperty("Spans")]
-	public class FormattedString : INotifyPropertyChanged
+	public class FormattedString : BindableObject
 	{
 		readonly SpanCollection _spans = new SpanCollection();
 
 		public FormattedString()
 		{
-			_spans.CollectionChanged += OnCollectionChanged;
+			_spans.CollectionChanged += OnCollectionChanged;			
+			BindingContextChanged += FormattedString_BindingContextChanged;
+		}
+
+		private void FormattedString_BindingContextChanged(object sender, EventArgs e)
+		{
+			foreach (var span in Spans)
+				SetInheritedBindingContext(span, BindingContext);
 		}
 
 		public IList<Span> Spans
 		{
 			get { return _spans; }
 		}
-
-		public event PropertyChangedEventHandler PropertyChanged;
-
+				
 		public static explicit operator string(FormattedString formatted)
 		{
 			return formatted.ToString();
@@ -57,6 +61,7 @@ namespace Xamarin.Forms
 				foreach (object item in e.NewItems)
 				{
 					var bo = item as Span;
+					SetInheritedBindingContext(bo, this.BindingContext);
 					if (bo != null)
 						bo.PropertyChanged += OnItemPropertyChanged;
 				}
@@ -68,13 +73,6 @@ namespace Xamarin.Forms
 		void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			OnPropertyChanged("Spans");
-		}
-
-		void OnPropertyChanged([CallerMemberName] string propertyName = null)
-		{
-			PropertyChangedEventHandler handler = PropertyChanged;
-			if (handler != null)
-				handler(this, new PropertyChangedEventArgs(propertyName));
 		}
 
 		class SpanCollection : ObservableCollection<Span>

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -40,7 +40,16 @@ namespace Xamarin.Forms
 			}, propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
 				if (newvalue != null)
-					((FormattedString)newvalue).PropertyChanged += ((Label)bindable).OnFormattedTextChanged;
+				{
+					var formattedString = (FormattedString)newvalue;
+					formattedString.PropertyChanged += ((Label)bindable).OnFormattedTextChanged;
+					SetInheritedBindingContext(formattedString, bindable.BindingContext);
+					bindable.BindingContextChanged += (s, e) =>
+					{
+						SetInheritedBindingContext(formattedString, bindable.BindingContext);
+					};
+				}
+
 				((Label)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 				if (newvalue != null)
 					((Label)bindable).Text = null;

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -36,7 +36,11 @@ namespace Xamarin.Forms
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{
 				if (oldvalue != null)
-					((FormattedString)oldvalue).PropertyChanged -= ((Label)bindable).OnFormattedTextChanged;
+				{
+					var formattedString = ((FormattedString)oldvalue);
+					formattedString.PropertyChanged -= ((Label)bindable).OnFormattedTextChanged;
+					SetInheritedBindingContext(formattedString, null);
+				}
 			}, propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
 				if (newvalue != null)
@@ -44,10 +48,6 @@ namespace Xamarin.Forms
 					var formattedString = (FormattedString)newvalue;
 					formattedString.PropertyChanged += ((Label)bindable).OnFormattedTextChanged;
 					SetInheritedBindingContext(formattedString, bindable.BindingContext);
-					bindable.BindingContextChanged += (s, e) =>
-					{
-						SetInheritedBindingContext(formattedString, bindable.BindingContext);
-					};
 				}
 
 				((Label)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
@@ -63,6 +63,13 @@ namespace Xamarin.Forms
 		public Label()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Label>>(() => new PlatformConfigurationRegistry<Label>(this));
+			BindingContextChanged += Label_BindingContextChanged;
+		}
+
+		void Label_BindingContextChanged(object sender, EventArgs e)
+		{
+			if (FormattedText != null)
+				SetInheritedBindingContext(FormattedText, this.BindingContext);
 		}
 
 		[Obsolete("Font is obsolete as of version 1.3.0. Please use the Font attributes which are on the class itself.")]

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -63,11 +63,11 @@ namespace Xamarin.Forms
 		public Label()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Label>>(() => new PlatformConfigurationRegistry<Label>(this));
-			BindingContextChanged += Label_BindingContextChanged;
 		}
 
-		void Label_BindingContextChanged(object sender, EventArgs e)
+		protected override void OnBindingContextChanged()
 		{
+			base.OnBindingContextChanged();
 			if (FormattedText != null)
 				SetInheritedBindingContext(FormattedText, this.BindingContext);
 		}

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -13,8 +13,14 @@ namespace Xamarin.Forms
 			_mergedStyle = new MergedStyle(GetType(), this);
 		}
 
-		public static readonly BindableProperty StyleProperty = BindableProperty.Create("Style", typeof(Style), typeof(VisualElement), default(Style),
+		public static readonly BindableProperty StyleProperty = BindableProperty.Create("Style", typeof(Style), typeof(Span), default(Style),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((Span)bindable)._mergedStyle.Style = (Style)newvalue);
+
+		public Style Style
+		{
+			get { return (Style)GetValue(StyleProperty); }
+			set { SetValue(StyleProperty, value); }
+		}
 
 		public static readonly BindableProperty BackgroundColorProperty
 			= BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(Span), default(Color));

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms
 {
 	[ContentProperty("Text")]
-	public sealed class Span : Element, IFontElement
+	public sealed class Span : Element, IFontElement, ITextElement
 	{
 		internal readonly MergedStyle _mergedStyle;
 
@@ -31,15 +31,17 @@ namespace Xamarin.Forms
 			set { SetValue(BackgroundColorProperty, value); }
 		}
 
-		[Obsolete("Foreground is obsolete as of version 2.6.0. Please use the TextColor property instead.")]
-		public static readonly BindableProperty ForegroundColorProperty
-			= BindableProperty.Create(nameof(ForegroundColor), typeof(Color), typeof(Span), default(Color), propertyChanged: ForegroundColorOnPropertyChanged);
+		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
-		static void ForegroundColorOnPropertyChanged(object bindable, object oldvalue, object newvalue)
+		public Color TextColor
 		{
-			((Span)bindable).TextColor = newvalue as Color? ?? default(Color);
+			get { return (Color)GetValue(TextElement.TextColorProperty); }
+			set { SetValue(TextElement.TextColorProperty, value); }
 		}
 
+		[Obsolete("Foreground is obsolete as of version 2.6.0. Please use the TextColor property instead.")]
+		public static readonly BindableProperty ForegroundColorProperty = TextColorProperty;
+		
 #pragma warning disable 618
 		public Color ForegroundColor
 		{
@@ -47,16 +49,7 @@ namespace Xamarin.Forms
 			set { SetValue(ForegroundColorProperty, value); }
 		}
 #pragma warning restore 618
-
-		public static readonly BindableProperty TextColorProperty
-			= BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Span), default(Color));
-
-		public Color TextColor
-		{
-			get { return (Color)GetValue(TextColorProperty); }
-			set { SetValue(TextColorProperty, value); }
-		}
-
+		
 		public static readonly BindableProperty TextProperty
 			= BindableProperty.Create(nameof(Text), typeof(string), typeof(Span), "");
 
@@ -112,11 +105,14 @@ namespace Xamarin.Forms
 			Device.GetNamedSize(NamedSize.Default, new Label());
 
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
-		{
-			
+		{			
 		}
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue)
+		{
+		}
+
+		void ITextElement.OnTextColorPropertyChanged(Color oldValue, Color newValue)
 		{
 		}
 	}

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -40,11 +40,13 @@ namespace Xamarin.Forms
 			((Span)bindable).TextColor = newvalue as Color? ?? default(Color);
 		}
 
+#pragma warning disable 618
 		public Color ForegroundColor
 		{
 			get { return (Color)GetValue(ForegroundColorProperty); }
 			set { SetValue(ForegroundColorProperty, value); }
 		}
+#pragma warning restore 618
 
 		public static readonly BindableProperty TextColorProperty
 			= BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Span), default(Color));
@@ -56,7 +58,7 @@ namespace Xamarin.Forms
 		}
 
 		public static readonly BindableProperty TextProperty
-			= BindableProperty.Create(nameof(Text), typeof(string), typeof(Span), null);
+			= BindableProperty.Create(nameof(Text), typeof(string), typeof(Span), "");
 
 		public string Text
 		{

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -4,102 +4,53 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms
 {
 	[ContentProperty("Text")]
-	public sealed class Span : BindableObject, IFontElement
+	public sealed class Span : Element, IFontElement
 	{
-		class BindableSpan : BindableObject, IFontElement
-		{
-			Span _span;
-			public BindableSpan(Span span)
-			{
-				_span = span;
-			}
-
-			public Font Font {
-				get { return (Font)GetValue(FontElement.FontProperty); }
-				set { SetValue(FontElement.FontProperty, value); }
-			}
-
-			public FontAttributes FontAttributes {
-				get { return (FontAttributes)GetValue(FontElement.FontAttributesProperty); }
-				set { SetValue(FontElement.FontAttributesProperty, value); }
-			}
-
-			public string FontFamily {
-				get { return (string)GetValue(FontElement.FontFamilyProperty); }
-				set { SetValue(FontElement.FontFamilyProperty, value); }
-			}
-
-			[TypeConverter(typeof(FontSizeConverter))]
-			public double FontSize {
-				get { return (double)GetValue(FontElement.FontSizeProperty); }
-				set { SetValue(FontElement.FontSizeProperty, value); }
-			}
-
-			double IFontElement.FontSizeDefaultValueCreator() =>
-				((IFontElement)_span).FontSizeDefaultValueCreator();
-
-			public void OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
-				((IFontElement)_span).OnFontAttributesChanged(oldValue, newValue);
-
-			public void OnFontChanged(Font oldValue, Font newValue) =>
-				((IFontElement)_span).OnFontChanged(oldValue, newValue);
-
-			public void OnFontFamilyChanged(string oldValue, string newValue) =>
-				((IFontElement)_span).OnFontFamilyChanged(oldValue, newValue);
-
-			public void OnFontSizeChanged(double oldValue, double newValue) =>
-				((IFontElement)_span).OnFontSizeChanged(oldValue, newValue);
-
-			protected override void OnPropertyChanged(string propertyName = null)
-			{
-				base.OnPropertyChanged(propertyName);
-				_span.OnPropertyChanged(propertyName);
-			}
-		}
-
-		BindableObject _fontElement;
-
-		Color _foregroundColor;
-
-		Color _backgroundColor;
+		internal readonly MergedStyle _mergedStyle;
 
 		public Span()
 		{
-			_fontElement = new BindableSpan(this);
+			_mergedStyle = new MergedStyle(GetType(), this);
 		}
+
+		public static readonly BindableProperty StyleProperty = BindableProperty.Create("Style", typeof(Style), typeof(VisualElement), default(Style),
+			propertyChanged: (bindable, oldvalue, newvalue) => ((Span)bindable)._mergedStyle.Style = (Style)newvalue);
+
+		public static readonly BindableProperty BackgroundColorProperty
+			= BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(Span), default(Color));
 
 		public Color BackgroundColor
 		{
-			get { return _backgroundColor; }
-			set
-			{
-				if (_backgroundColor == value)
-					return;
-				_backgroundColor = value;
-				OnPropertyChanged();
-			}
+			get { return (Color)GetValue(BackgroundColorProperty); }
+			set { SetValue(BackgroundColorProperty, value); }
 		}
 
-		[Obsolete("Font is obsolete as of version 1.3.0. Please use the Font properties directly.")]
-		public Font Font {
-			get { return (Font)_fontElement.GetValue(FontElement.FontProperty); }
-			set { _fontElement.SetValue(FontElement.FontProperty, value); }
+		[Obsolete("Foreground is obsolete as of version 2.6.0. Please use the TextColor property instead.")]
+		public static readonly BindableProperty ForegroundColorProperty
+			= BindableProperty.Create(nameof(ForegroundColor), typeof(Color), typeof(Span), default(Color), propertyChanged: ForegroundColorOnPropertyChanged);
+
+		static void ForegroundColorOnPropertyChanged(object bindable, object oldvalue, object newvalue)
+		{
+			((Span)bindable).TextColor = newvalue as Color? ?? default(Color);
 		}
-		
+
 		public Color ForegroundColor
 		{
-			get { return _foregroundColor; }
-			set
-			{
-				if (_foregroundColor == value)
-					return;
-				_foregroundColor = value;
-				OnPropertyChanged();
-			}
+			get { return (Color)GetValue(ForegroundColorProperty); }
+			set { SetValue(ForegroundColorProperty, value); }
+		}
+
+		public static readonly BindableProperty TextColorProperty
+			= BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Span), default(Color));
+
+		public Color TextColor
+		{
+			get { return (Color)GetValue(TextColorProperty); }
+			set { SetValue(TextColorProperty, value); }
 		}
 
 		public static readonly BindableProperty TextProperty
-			= BindableProperty.Create("Text", typeof(string), typeof(Span), null);
+			= BindableProperty.Create(nameof(Text), typeof(string), typeof(Span), null);
 
 		public string Text
 		{
@@ -107,23 +58,38 @@ namespace Xamarin.Forms
 			set	{ SetValue(TextProperty, value); }
 		}
 
+		public static readonly BindableProperty FontProperty = FontElement.FontProperty;
+
+		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
+
+		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
+
+		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
+
+		[Obsolete("Font is obsolete as of version 1.3.0. Please use the Font properties directly.")]
+		public Font Font
+		{
+			get { return (Font)GetValue(FontElement.FontProperty); }
+			set { SetValue(FontElement.FontProperty, value); }
+		}
+
 		public FontAttributes FontAttributes
 		{
-			get { return (FontAttributes)_fontElement.GetValue(FontElement.FontAttributesProperty); }
-			set { _fontElement.SetValue(FontElement.FontAttributesProperty, value); }
+			get { return (FontAttributes)GetValue(FontElement.FontAttributesProperty); }
+			set { SetValue(FontElement.FontAttributesProperty, value); }
 		}
 
 		public string FontFamily
 		{
-			get { return (string)_fontElement.GetValue(FontElement.FontFamilyProperty); }
-			set { _fontElement.SetValue(FontElement.FontFamilyProperty, value); }
+			get { return (string)GetValue(FontElement.FontFamilyProperty); }
+			set { SetValue(FontElement.FontFamilyProperty, value); }
 		}
 
 		[TypeConverter(typeof(FontSizeConverter))]
 		public double FontSize
 		{
-			get { return (double)_fontElement.GetValue(FontElement.FontSizeProperty); }
-			set { _fontElement.SetValue(FontElement.FontSizeProperty, value); }
+			get { return (double)GetValue(FontElement.FontSizeProperty); }
+			set { SetValue(FontElement.FontSizeProperty, value); }
 		}
 
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
@@ -139,6 +105,7 @@ namespace Xamarin.Forms
 
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
 		{
+			
 		}
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue)

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -1,12 +1,10 @@
 using System;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
 	[ContentProperty("Text")]
-	public sealed class Span : INotifyPropertyChanged, IFontElement
+	public sealed class Span : BindableObject, IFontElement
 	{
 		class BindableSpan : BindableObject, IFontElement
 		{
@@ -59,13 +57,11 @@ namespace Xamarin.Forms
 			}
 		}
 
-		Color _backgroundColor;
-
 		BindableObject _fontElement;
 
 		Color _foregroundColor;
 
-		string _text;
+		Color _backgroundColor;
 
 		public Span()
 		{
@@ -89,7 +85,7 @@ namespace Xamarin.Forms
 			get { return (Font)_fontElement.GetValue(FontElement.FontProperty); }
 			set { _fontElement.SetValue(FontElement.FontProperty, value); }
 		}
-
+		
 		public Color ForegroundColor
 		{
 			get { return _foregroundColor; }
@@ -102,16 +98,13 @@ namespace Xamarin.Forms
 			}
 		}
 
+		public static readonly BindableProperty TextProperty
+			= BindableProperty.Create("Text", typeof(string), typeof(Span), null);
+
 		public string Text
 		{
-			get { return _text; }
-			set
-			{
-				if (_text == value)
-					return;
-				_text = value;
-				OnPropertyChanged();
-			}
+			get { return (string)GetValue(TextProperty); }
+			set	{ SetValue(TextProperty, value); }
 		}
 
 		public FontAttributes FontAttributes
@@ -131,15 +124,6 @@ namespace Xamarin.Forms
 		{
 			get { return (double)_fontElement.GetValue(FontElement.FontSizeProperty); }
 			set { _fontElement.SetValue(FontElement.FontSizeProperty, value); }
-		}
-
-		public event PropertyChangedEventHandler PropertyChanged;
-
-		void OnPropertyChanged([CallerMemberName] string propertyName = null)
-		{
-			PropertyChangedEventHandler handler = PropertyChanged;
-			if (handler != null)
-				handler(this, new PropertyChangedEventArgs(propertyName));
 		}
 
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Forms
 
 		readonly Dictionary<Size, SizeRequest> _measureCache = new Dictionary<Size, SizeRequest>();
 
-		readonly MergedStyle _mergedStyle;
+		internal readonly MergedStyle _mergedStyle;
 
 		int _batched;
 		LayoutConstraint _computedConstraint;

--- a/Xamarin.Forms.Platform.Android/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormattedStringExtensions.cs
@@ -35,9 +35,9 @@ namespace Xamarin.Forms.Platform.Android
 				int end = start + span.Text.Length;
 				c = end;
 
-				if (span.ForegroundColor != Color.Default)
+				if (span.TextColor != Color.Default)
 				{
-					spannable.SetSpan(new ForegroundColorSpan(span.ForegroundColor.ToAndroid()), start, end, SpanTypes.InclusiveExclusive);
+					spannable.SetSpan(new ForegroundColorSpan(span.TextColor.ToAndroid()), start, end, SpanTypes.InclusiveExclusive);
 				}
 				else if (defaultForegroundColor != Color.Default)
 				{

--- a/Xamarin.Forms.Platform.GTK/Extensions/LabelExtensions.cs
+++ b/Xamarin.Forms.Platform.GTK/Extensions/LabelExtensions.cs
@@ -56,9 +56,9 @@ namespace Xamarin.Forms.Platform.GTK.Extensions
             }
 
             // ForegroundColor => 
-            if (!span.ForegroundColor.IsDefault)
+            if (!span.TextColor.IsDefault)
             {
-                builder.AppendFormat(" fgcolor=\"{0}\"", span.ForegroundColor.ToRgbaColor());
+                builder.AppendFormat(" fgcolor=\"{0}\"", span.TextColor.ToRgbaColor());
             }
 
             builder.Append(">"); // Complete opening span tag

--- a/Xamarin.Forms.Platform.Tizen/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/CellRenderer.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			var nativeSpan = new Native.Span();
 			nativeSpan.Text = span.Text;
-			nativeSpan.ForegroundColor = span.ForegroundColor.ToNative();
+			nativeSpan.ForegroundColor = span.TextColor.ToNative();
 			nativeSpan.FontAttributes = span.FontAttributes;
 			nativeSpan.BackgroundColor = span.BackgroundColor.ToNative();
 			nativeSpan.FontSize = span.FontSize;

--- a/Xamarin.Forms.Platform.Tizen/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/TextCellRenderer.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			return new Span()
 			{
 				Text = cell.Text,
-				ForegroundColor = cell.TextColor,
+				TextColor = cell.TextColor,
 				FontSize = -1
 			};
 		}
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			return new Span()
 			{
 				Text = cell.Detail,
-				ForegroundColor = cell.DetailColor,
+				TextColor = cell.DetailColor,
 				FontSize = -1
 			};
 		}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/LabelRenderer.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				nativeSpan.FontAttributes = span.FontAttributes;
 				nativeSpan.FontFamily = span.FontFamily;
 				nativeSpan.FontSize = span.FontSize;
-				nativeSpan.ForegroundColor = span.ForegroundColor.ToNative();
+				nativeSpan.ForegroundColor = span.TextColor.ToNative();
 				nativeSpan.BackgroundColor = span.BackgroundColor.ToNative();
 				nativeString.Spans.Add(nativeSpan);
 			}

--- a/Xamarin.Forms.Platform.UAP/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/LabelRenderer.cs
@@ -14,8 +14,8 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			var run = new Run { Text = span.Text ?? string.Empty };
 
-			if (span.ForegroundColor != Color.Default)
-				run.Foreground = span.ForegroundColor.ToBrush();
+			if (span.TextColor != Color.Default)
+				run.Foreground = span.TextColor.ToBrush();
 
 			if (!span.IsDefault())
 #pragma warning disable 618

--- a/Xamarin.Forms.Platform.WPF/Extensions/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.WPF/Extensions/FormattedStringExtensions.cs
@@ -19,8 +19,8 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			var run = new Run { Text = span.Text };
 
-			if (span.ForegroundColor != Color.Default)
-				run.Foreground = span.ForegroundColor.ToBrush();
+			if (span.TextColor != Color.Default)
+				run.Foreground = span.TextColor.ToBrush();
 
 			if (!span.IsDefault())
 #pragma warning disable 618

--- a/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.Platform.MacOS
 #pragma warning disable 0618 //retaining legacy call to obsolete code
 			var font = span.Font != Font.Default ? span.Font : defaultFont;
 #pragma warning restore 0618
-			var fgcolor = span.ForegroundColor;
+			var fgcolor = span.TextColor;
 			if (fgcolor.IsDefault)
 				fgcolor = defaultForegroundColor;
 			if (fgcolor.IsDefault)
@@ -64,7 +64,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			else
 				targetFont = span.ToUIFont();
 
-			var fgcolor = span.ForegroundColor;
+			var fgcolor = span.TextColor;
 			if (fgcolor.IsDefault)
 				fgcolor = defaultForegroundColor;
 			if (fgcolor.IsDefault)
@@ -78,7 +78,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			else
 				targetFont = span.ToNSFont();
 
-			var fgcolor = span.ForegroundColor;
+			var fgcolor = span.TextColor;
 			if (fgcolor.IsDefault)
 				fgcolor = defaultForegroundColor;
 			if (fgcolor.IsDefault)

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FormattedString.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FormattedString.xml
@@ -1,6 +1,6 @@
 <Type Name="FormattedString" FullName="Xamarin.Forms.FormattedString">
-  <TypeSignature Language="C#" Value="public class FormattedString : System.ComponentModel.INotifyPropertyChanged" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FormattedString extends System.Object implements class System.ComponentModel.INotifyPropertyChanged" />
+  <TypeSignature Language="C#" Value="public class FormattedString : Xamarin.Forms.BindableObject" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FormattedString extends Xamarin.Forms.BindableObject" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
@@ -10,12 +10,9 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Base>
-    <BaseTypeName>System.Object</BaseTypeName>
+    <BaseTypeName>Xamarin.Forms.BindableObject</BaseTypeName>
   </Base>
   <Interfaces>
-    <Interface>
-      <InterfaceName>System.ComponentModel.INotifyPropertyChanged</InterfaceName>
-    </Interface>
   </Interfaces>
   <Attributes>
     <Attribute>
@@ -42,6 +39,22 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the FormattedString class.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="OnBindingContextChanged">
+      <MemberSignature Language="C#" Value="protected override void OnBindingContextChanged ();" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void OnBindingContextChanged() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -102,7 +115,6 @@
         <AssemblyVersion>1.3.0.0</AssemblyVersion>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.ComponentModel.PropertyChangedEventHandler</ReturnType>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Label.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Label.xml
@@ -457,6 +457,22 @@ public class App : Application
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="OnBindingContextChanged">
+      <MemberSignature Language="C#" Value="protected override void OnBindingContextChanged ();" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void OnBindingContextChanged() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Text">
       <MemberSignature Language="C#" Value="public string Text { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Text" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Span.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Span.xml
@@ -1,6 +1,6 @@
 <Type Name="Span" FullName="Xamarin.Forms.Span">
-  <TypeSignature Language="C#" Value="public sealed class Span : System.ComponentModel.INotifyPropertyChanged, Xamarin.Forms.Internals.IFontElement" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed beforefieldinit Span extends System.Object implements class System.ComponentModel.INotifyPropertyChanged, class Xamarin.Forms.Internals.IFontElement" />
+  <TypeSignature Language="C#" Value="public sealed class Span : Xamarin.Forms.Element, Xamarin.Forms.Internals.IFontElement" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed beforefieldinit Span extends Xamarin.Forms.Element implements class Xamarin.Forms.Internals.IFontElement" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
@@ -10,12 +10,9 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Base>
-    <BaseTypeName>System.Object</BaseTypeName>
+    <BaseTypeName>Xamarin.Forms.Element</BaseTypeName>
   </Base>
   <Interfaces>
-    <Interface>
-      <InterfaceName>System.ComponentModel.INotifyPropertyChanged</InterfaceName>
-    </Interface>
     <Interface>
       <InterfaceName>Xamarin.Forms.Internals.IFontElement</InterfaceName>
     </Interface>
@@ -67,6 +64,21 @@
         <remarks>Not supported on WindowsPhone.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="BackgroundColorProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty BackgroundColorProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty BackgroundColorProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Font">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.Font Font { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Font Font" />
@@ -111,6 +123,21 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="FontAttributesProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontAttributesProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontAttributesProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="FontFamily">
       <MemberSignature Language="C#" Value="public string FontFamily { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string FontFamily" />
@@ -127,6 +154,36 @@
       <Docs>
         <summary>Gets the font family to which the font for the text in the span belongs.</summary>
         <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontFamilyProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontFamilyProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontFamilyProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -154,6 +211,21 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="FontSizeProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontSizeProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontSizeProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="ForegroundColor">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.Color ForegroundColor { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Color ForegroundColor" />
@@ -174,6 +246,26 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="ForegroundColorProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty ForegroundColorProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty ForegroundColorProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Obsolete("Foreground is obsolete as of version 2.6.0. Please use the TextColor property instead.")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="PropertyChanged">
       <MemberSignature Language="C#" Value="public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;" />
       <MemberSignature Language="ILAsm" Value=".event class System.ComponentModel.PropertyChangedEventHandler PropertyChanged" />
@@ -183,13 +275,43 @@
         <AssemblyVersion>1.3.0.0</AssemblyVersion>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.ComponentModel.PropertyChangedEventHandler</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when a property is changed.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Style">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Style Style { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.Style Style" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Style</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="StyleProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty StyleProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty StyleProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -210,6 +332,52 @@
       <Docs>
         <summary>Gets or sets the text of the span.</summary>
         <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TextColor">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Color TextColor { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Color TextColor" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TextColorProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty TextColorProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty TextColorProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TextProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty TextProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty TextProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
### Description of Change ###

This allows Text to be Bindable on a Span.
It also added the Style property to the Span, to set the Font Elements. 

![2018-02-01 23_04_45-android emulator - nexus_6_api_25_5554](https://user-images.githubusercontent.com/13672662/35720187-b5e759e0-0840-11e8-8dc1-33fd67c6cffb.png)

### Bugs Fixed ###

N/A

### API Changes ###

Added:
 - TextColor { get; set; } // Bindable Property

Marked Obsolete:
 - ForegroundColor { get; set; }

ForegroundColor now just updates TextColor

### Behavioral Changes ###

N/A

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense