### PR TITLE
[Enhancement] UWP PlatformSpecific to display JavaScript alerts in WebView

### DIFF
--- a/.nuspec/Xamarin.Forms.Maps.GTK.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.GTK.nuspec
@@ -18,13 +18,6 @@
         <dependency id="Xamarin.Forms.Maps$IdAppend$" version="$version$" />
       </group>
     </dependencies>
-    <references>
-      <group>
-        <reference file="GMap.NET.Core.dll" />
-        <reference file="GMap.NET.GTK.dll" />
-        <reference file="Xamarin.Forms.Maps.GTK.dll" />
-      </group>
-    </references>
   </metadata>
   <files>
     <file src="..\Xamarin.Forms.Platform.GTK\Libs\GMaps\GMap.NET.Core.dll" target="lib\net45" />

--- a/.nuspec/Xamarin.Forms.Platform.GTK.nuspec
+++ b/.nuspec/Xamarin.Forms.Platform.GTK.nuspec
@@ -17,13 +17,6 @@
         <dependency id="Xamarin.Forms$IdAppend$" version="$version$" />
       </group>
     </dependencies>
-    <references>
-      <group>
-        <reference file="OpenTK.dll" />
-        <reference file="webkit-sharp.dll" />
-        <reference file="Xamarin.Forms.Platform.GTK.dll" />
-      </group>
-    </references>
   </metadata>
   <files>
     <file src="..\Xamarin.Forms.Platform.GTK\Libs\OpenTK\OpenTK.dll" target="lib\net45"/>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <img src="banner.png" alt="Xamarin.Forms banner" height="145" >
 
 # Xamarin.Forms #
@@ -6,23 +7,37 @@ Xamarin.Forms provides a way to quickly build native apps for iOS, Android, Wind
 
 Read more about the platform at https://www.xamarin.com/forms.
 
-## Build Status ##
+## Build Status 
 
-![OSX Debug Teamcity](https://img.shields.io/teamcity/https/teamcity.xamarin.com/e/XamarinForms_Debug_Cycle8ezTest_OsxDebug.svg?style=flat&label=OSX%20Debug%20%20%20%20%20 "OSX Debug")  
+![Visual Studio Team Services ](https://img.shields.io/vso/build/devdiv/0bdbc590-a062-4c3f-b0f6-9383f67865ee/7981.svg?style=flat&label=VSTS%20Master "VSTS")
+ 
 
-![Windows Debug Teamcity](https://img.shields.io/teamcity/https/teamcity.xamarin.com/e/XamarinForms_Debug_Cycle8ezTest_WindowsDebug.svg?style=flat&label=Win%20Debug%20%20%20%20%20%20 "Win Debug")  
+## Packages ##
 
-![Android UI Tests Teamcity](https://img.shields.io/teamcity/https/teamcity.xamarin.com/e/XamarinForms_Debug_Cycle8ezTest_UiTests_OsxTestCloudPackageRunAndroid601.svg?style=flat&label=UITest%20Android "Android UI Tests")
 
-![iOS8 UI Tests Teamcity](https://img.shields.io/teamcity/https/teamcity.xamarin.com/e/XamarinForms_Debug_Cycle8ezTest_UiTests_OsxTestCloudPackageRunIOSUnifiedIOS8.svg?style=flat&label=UITest%20iOS8%20%20%20%20 "iOS8 UI Tests")  
+Platform/Feature               | Package name                              | Stable (2.5.0 branch)     |Nightly Feed [MyGet](https://www.myget.org/F/xamarinforms-ci/api/v2)  (master branch)
+-----------------------|-------------------------------------------|-----------------------------|-------------------------
+Core             | `Xamarin.Forms` | [![NuGet](https://img.shields.io/nuget/v/Xamarin.Forms.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms/)| [![MyGet](https://img.shields.io/myget/xamarinforms-ci/vpre/Xamarin.Forms.svg?style=flat-square&label=myget)](https://myget.org/feed/aspnetcore-dev/package/nuget/Xamarin.Forms)
+Maps                 | `Xamarin.Forms.Maps`    | [![NuGet](https://img.shields.io/nuget/v/Xamarin.Forms.Maps.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms.Maps/) | [![MyGet](https://img.shields.io/myget/xamarinforms-ci/vpre/Xamarin.Forms.Maps.svg?style=flat-square&label=myget)](https://myget.org/feed/xamarinforms-ci/package/nuget/Xamarin.Forms.Maps)
+Pages  | `Xamarin.Forms.Pages`  | [![NuGet](https://img.shields.io/nuget/v/Xamarin.Forms.Pages.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms.Pages/) | [![MyGet](https://img.shields.io/myget/xamarinforms-ci/vpre/Xamarin.Forms.Pages.svg?style=flat-square&label=myget)](https://myget.org/feed/xamarin.forms-ci/package/nuget/Xamarin.Forms.Pages)
 
-![iOS9 UI Tests Teamcity](https://img.shields.io/teamcity/https/teamcity.xamarin.com/e/XamarinForms_Debug_Cycle8ezTest_UiTests_OsxTestCloudPackageRunIOSUnifiedIOS9.svg?style=flat&label=UITest%20iOS9%20%20%20%20 "iOS9 UI Tests")  
+If you want to use the latest dev build then you should read [this blog post]( https://blog.xamarin.com/try-the-latest-in-xamarin-forms-with-nightly-builds) :
+- Add the nightly feed to your nuget sources or add a NuGet.Config to your app with the following content:
 
-![iOS10 UI Tests Teamcity](https://img.shields.io/teamcity/https/teamcity.xamarin.com/e/XamarinForms_Debug_Cycle8ezTest_UiTests_OsxTestCloudPackageRunIOSUnifiedIOS10.svg?style=flat&label=UITest%20iOS10%20%20 "iOS10 UI Tests") 
+  ```xml
+  <?xml version="1.0" encoding="utf-8"?>
+  <configuration>
+      <packageSources>
+          <clear />
+          <add key="xamarin-ci" value="https://www.myget.org/F/xamarinforms-ci/api/v2" />
+          <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+      </packageSources>
+  </configuration>
+  ```
 
-![Visual Studio Team Services Windows Debug](https://img.shields.io/vso/build/devdiv/0bdbc590-a062-4c3f-b0f6-9383f67865ee/6713.svg?style=flat&label=VSTS%20Win%20dbg "Win Debug VSTS")
+  *NOTE: This NuGet.Config should be with your application unless you want nightly packages to potentially start being restored for other apps on the machine.*
 
-![Visual Studio Team Services OSX Debug](https://img.shields.io/vso/build/devdiv/0bdbc590-a062-4c3f-b0f6-9383f67865ee/5514.svg?style=flat&label=VSTS%20OSX%20dbg "OSX Debug VSTS") 
+- Change your application's dependencies to have a `*` to get the latest version.
 
 
 ## Getting Started ##
@@ -53,6 +68,24 @@ Due to the way that Android works, the maps API key cannot be injected at runtim
 
 You can find out how to obtain a Google Maps API key [here](https://developer.xamarin.com/guides/android/platform_features/maps_and_location/maps/obtaining_a_google_maps_api_key/).
 
+##### Build from the Command line #####
+Make sure you have Nuget.exe 4.0 or above and the latest dotnet core sdk (2.0.3). On OSX you should specify the platform in the msbuild command (`/p:Platform=iPhoneSimulator`)
+  
+
+     nuget restore Xamarin.Forms.sln
+     msbuild Xamarin.Forms.sln
+ 
+
+##### API documentation changes #####
+If you change or add a public API on Xamarin.Forms the associated documentation should be updated and pushed as part of the pull request. This will also be needed to create a local nuget if you want. We rely on mdoc that is shipped in the repo on the tools folder. After building the .sln on Windows run:
+     
+     ./update-docs-windows.bat
+
+on OSX execute:
+     
+     make docs
+
+
 ## Coding Style ##
 We follow the style used by the [.NET Foundation](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md), with a few exceptions:
 
@@ -67,5 +100,4 @@ We follow the style used by the [.NET Foundation](https://github.com/dotnet/core
 ### Reporting Bugs
 
 We use [GitHub Issues](https://github.com/xamarin/Xamarin.Forms/issues) to track issues. If at all possible, please submit a [reproduction of your bug](https://gist.github.com/jassmith/92405c300e54a01dcc6d) along with your bug report.
-
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CascadeInputTransparent.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CascadeInputTransparent.cs
@@ -18,8 +18,8 @@ namespace Xamarin.Forms.Controls.Issues
 	#endif
 
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.None, 5552368, "Transparency Inheritance", PlatformAffected.All)]
-	public class InputTransparentInheritance : TestNavigationPage
+	[Issue(IssueTracker.None, 5552368, "Transparency Cascading", PlatformAffected.All)]
+	public class CascadeInputTransparent : TestNavigationPage
 	{
 		const string Running = "Running...";
 		const string Success = "Success";
@@ -28,10 +28,10 @@ namespace Xamarin.Forms.Controls.Issues
 		const string OverButtonText = "+";
 		const string Overlay = "overlay";
 
-		const string InheritedStatic = "Inherited";
-		const string InheritedChange = "Inherited (changes)";
-		const string NotInheritedStatic = "Not Inherited";
-		const string NotInheritedChange = "Not Inherited (changes)";
+		const string CascadesStatic = "Cascades";
+		const string CascadesChange = "Cascades (changes)";
+		const string NotCascadingStatic = "Not Cascading";
+		const string NotCascadingChange = "Not Cascading (changes)";
 
 		protected override void Init()
 		{
@@ -52,22 +52,22 @@ namespace Xamarin.Forms.Controls.Issues
 			return new ContentPage { Content = layout };
 		}
 
-		Button MenuButton(bool inherited, bool transition)
+		Button MenuButton(bool cascades, bool transition)
 		{
-			var text = inherited
-				? transition ? InheritedChange : InheritedStatic
+			var text = cascades
+				? transition ? CascadesChange : CascadesStatic
 				: transition
-				? NotInheritedChange
-				: NotInheritedStatic;
+				? NotCascadingChange
+				: NotCascadingStatic;
 
 			var button = new Button { Text = text, AutomationId = text };
 
-			button.Clicked += (sender, args) => PushAsync(CreateTestPage(inherited, transition));
+			button.Clicked += (sender, args) => PushAsync(CreateTestPage(cascades, transition));
 
 			return button;
 		}
 
-		static ContentPage CreateTestPage(bool inherited, bool transition)
+		static ContentPage CreateTestPage(bool cascades, bool transition)
 		{
 			var grid = new Grid
 			{
@@ -115,7 +115,7 @@ namespace Xamarin.Forms.Controls.Issues
 			underButton.Clicked += (sender, args) =>
 			{
 				underPressed = true;
-				EvaluateTest(results, inherited, overPressed, underPressed, layoutTapped);
+				EvaluateTest(results, cascades, overPressed, underPressed, layoutTapped);
 			};
 
 			var overButton = new Button
@@ -127,7 +127,7 @@ namespace Xamarin.Forms.Controls.Issues
 			overButton.Clicked += (sender, args) =>
 			{
 				overPressed = true;
-				EvaluateTest(results, inherited, overPressed, underPressed, layoutTapped);
+				EvaluateTest(results, cascades, overPressed, underPressed, layoutTapped);
 			};
 
 			var layout = new StackLayout
@@ -136,7 +136,7 @@ namespace Xamarin.Forms.Controls.Issues
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill,
 				InputTransparent = true,
-				InputTransparentInherited = inherited,
+				CascadeInputTransparent = cascades,
 				BackgroundColor = Color.Blue,
 				Opacity = 0.2
 			};
@@ -146,7 +146,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Command = new Command(() =>
 				{
 					layoutTapped = true;
-					EvaluateTest(results, inherited, overPressed, underPressed, layoutTapped);
+					EvaluateTest(results, cascades, overPressed, underPressed, layoutTapped);
 				})
 			});
 
@@ -161,22 +161,22 @@ namespace Xamarin.Forms.Controls.Issues
 			grid.Children.Add(layout);
 			Grid.SetRow(layout, 2);
 
-			var page = new ContentPage { Content = grid, Title = inherited.ToString() };
+			var page = new ContentPage { Content = grid, Title = cascades.ToString() };
 
 			if (transition)
 			{
 				page.Appearing += async (sender, args) =>
 				{
 					await Task.Delay(1000);
-					inherited = !inherited;
-					layout.InputTransparentInherited = inherited;
+					cascades = !cascades;
+					layout.CascadeInputTransparent = cascades;
 				};
 			}
 
 			return page;
 		}
 
-		static void EvaluateTest(Label results, bool inherited, bool overPressed, bool underPressed, bool layoutTapped)
+		static void EvaluateTest(Label results, bool cascades, bool overPressed, bool underPressed, bool layoutTapped)
 		{
 			if (layoutTapped)
 			{
@@ -184,7 +184,7 @@ namespace Xamarin.Forms.Controls.Issues
 				return;
 			}
 
-			if (inherited)
+			if (cascades)
 			{
 				if (overPressed)
 				{
@@ -210,11 +210,11 @@ namespace Xamarin.Forms.Controls.Issues
 			results.Text = Running;
 		}
 
-		static IEnumerable<string> TestList => new List<string> { InheritedChange, InheritedStatic, NotInheritedChange, NotInheritedStatic };
+		static IEnumerable<string> TestList => new List<string> { CascadesChange, CascadesStatic, NotCascadingChange, NotCascadingStatic };
 
 		#if UITEST
 		[Test, TestCaseSource(nameof(TestList))]
-		public void TransparencyNotInherited(string test)
+		public void TransparencyCascading(string test)
 		{
 			RunningApp.WaitForElement(test);
 			RunningApp.Tap(test);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -257,7 +257,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Effects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FailImageSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GestureBubblingTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)InputTransparentInheritance.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CascadeInputTransparent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1331.xaml.cs">
       <DependentUpon>GitHub1331.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
@@ -1,4 +1,6 @@
 using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
 namespace Xamarin.Forms.Controls
 {
@@ -54,9 +56,32 @@ namespace Xamarin.Forms.Controls
 				}
 			);
 
+			var jsAlertWebView = new WebView
+			{
+				Source = new HtmlWebViewSource
+				{
+					Html = @"<html>
+<head>
+<link rel=""stylesheet"" href=""default.css"">
+</head>
+<body>
+<button onclick=""window.alert('foo');"">Click</button>
+</body>
+</html>"
+				},
+				HeightRequest = 200
+			};
+
+			jsAlertWebView.On<Windows>().SetIsJavaScriptAlertEnabled(true);
+			
+			var javascriptAlertWebSourceContainer = new ViewContainer<WebView>(Test.WebView.JavaScriptAlert,
+				jsAlertWebView
+			);
+
 			Add (urlWebViewSourceContainer);
 			Add (htmlWebViewSourceContainer);
 			Add (htmlFileWebSourceContainer);
+			Add (javascriptAlertWebSourceContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/WebViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/WebViewUnitTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 
 using NUnit.Framework;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -88,6 +90,18 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual ("<html><body><p>This is a WebView!</p></body></html>", htmlSource.Html);
 			Assert.AreEqual ("http://xamarin.com", urlSource.Url);
+		}
+
+		[Test]
+		public void TestWindowsSetAllowJavaScriptAlertsFlag()
+		{
+			var defaultWebView = new WebView();
+
+			var jsAlertsAllowedWebView = new WebView();
+			jsAlertsAllowedWebView.On<Windows>().SetIsJavaScriptAlertEnabled(true);
+
+			Assert.AreEqual(defaultWebView.On<Windows>().IsJavaScriptAlertEnabled(), false);
+			Assert.AreEqual(jsAlertsAllowedWebView.On<Windows>().IsJavaScriptAlertEnabled(), true);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -54,8 +54,8 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty IsClippedToBoundsProperty = BindableProperty.Create("IsClippedToBounds", typeof(bool), typeof(Layout), false);
 
-		public static readonly BindableProperty InputTransparentInheritedProperty = BindableProperty.Create(
-			"InputTransparentInherited", typeof(bool), typeof(Layout), true);
+		public static readonly BindableProperty CascadeInputTransparentProperty = BindableProperty.Create(
+			nameof(CascadeInputTransparent), typeof(bool), typeof(Layout), true);
 
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
@@ -89,10 +89,10 @@ namespace Xamarin.Forms
 			set { SetValue(PaddingElement.PaddingProperty, value); }
 		}
 
-		public bool InputTransparentInherited
+		public bool CascadeInputTransparent
 		{
-			get { return (bool)GetValue(InputTransparentInheritedProperty); }
-			set { SetValue(InputTransparentInheritedProperty, value); }
+			get { return (bool)GetValue(CascadeInputTransparentProperty); }
+			set { SetValue(CascadeInputTransparentProperty, value); }
 		}
 
 		Thickness IPaddingElement.PaddingDefaultValueCreator()

--- a/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/WebView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/WebView.cs
@@ -1,0 +1,31 @@
+﻿
+namespace Xamarin.Forms.PlatformConfiguration.WindowsSpecific
+{
+	using FormsElement = Forms.WebView;
+
+    public static class WebView
+    {
+		public static readonly BindableProperty IsJavaScriptAlertEnabledProperty = BindableProperty.Create("IsJavaScriptAlertEnabled", typeof(bool), typeof(WebView), false);
+
+		public static bool GetIsJavaScriptAlertEnabled(BindableObject element)
+		{
+			return (bool)element.GetValue(IsJavaScriptAlertEnabledProperty);
+		}
+
+		public static void SetIsJavaScriptAlertEnabled(BindableObject element, bool value)
+		{
+			element.SetValue(IsJavaScriptAlertEnabledProperty, value);
+		}
+
+		public static bool IsJavaScriptAlertEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
+		{
+			return GetIsJavaScriptAlertEnabled(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Windows, FormsElement> SetIsJavaScriptAlertEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
+		{
+			SetIsJavaScriptAlertEnabled(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -679,7 +679,8 @@ namespace Xamarin.Forms.CustomAttributes
 		public enum WebView {
 			UrlWebViewSource,
 			HtmlWebViewSource,
-			LoadHtml
+			LoadHtml,
+			JavaScriptAlert
 		}
 
 		public enum UrlWebViewSource {

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -283,7 +283,7 @@ namespace Xamarin.Forms.Platform.Android
 				SetFocusable();
 			else if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
 				UpdateInputTransparent();
-			else if (e.PropertyName == Xamarin.Forms.Layout.InputTransparentInheritedProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.Layout.CascadeInputTransparentProperty.PropertyName)
 				UpdateInputTransparentInherited();
 
 			ElementPropertyChanged?.Invoke(this, e);
@@ -340,7 +340,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			_inputTransparentInherited = layout.InputTransparentInherited;
+			_inputTransparentInherited = layout.CascadeInputTransparent;
 		}
 
 		protected void SetPackager(VisualElementPackager packager)

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -90,11 +90,11 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateGrouping();
 			}
-			else if (e.PropertyName == ListView.HeaderProperty.PropertyName)
+			else if (e.PropertyName == ListView.HeaderProperty.PropertyName || e.PropertyName == "HeaderElement")
 			{
 				UpdateHeader();
 			}
-			else if (e.PropertyName == ListView.FooterProperty.PropertyName)
+			else if (e.PropertyName == ListView.FooterProperty.PropertyName || e.PropertyName == "FooterElement")
 			{
 				UpdateFooter();
 			}

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -310,7 +310,7 @@ namespace Xamarin.Forms.Platform.UWP
 			else if (e.PropertyName == AutomationProperties.LabeledByProperty.PropertyName)
 				SetAutomationPropertiesLabeledBy();
 			else if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName || 
-					e.PropertyName == Layout.InputTransparentInheritedProperty.PropertyName)
+					e.PropertyName == Layout.CascadeInputTransparentProperty.PropertyName)
 				UpdateInputTransparent();
 		}
 
@@ -616,7 +616,7 @@ namespace Xamarin.Forms.Platform.UWP
 				return false;
 			}
 
-			if (layout.IsEnabled && layout.InputTransparent && !layout.InputTransparentInherited)
+			if (layout.IsEnabled && layout.InputTransparent && !layout.CascadeInputTransparent)
 			{
 				return true;
 			}

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -510,7 +510,7 @@ namespace Xamarin.Forms.Platform.iOS
 					Alpha = old;
 				}
 
-				if (UserInteractionEnabled && Element is Layout layout && !layout.InputTransparentInherited)
+				if (UserInteractionEnabled && Element is Layout layout && !layout.CascadeInputTransparent)
 				{
 					// This is a Layout with 'InputTransparent = true' and 'InputTransparentInherited = false'
 					if (this.Equals(result))

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -83,7 +83,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				e.PropertyName == VisualElement.RotationProperty.PropertyName || e.PropertyName == VisualElement.RotationXProperty.PropertyName || e.PropertyName == VisualElement.RotationYProperty.PropertyName ||
 				e.PropertyName == VisualElement.IsVisibleProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName ||
 				e.PropertyName == VisualElement.InputTransparentProperty.PropertyName || e.PropertyName == VisualElement.OpacityProperty.PropertyName || 
-				e.PropertyName == Layout.InputTransparentInheritedProperty.PropertyName)
+				e.PropertyName == Layout.CascadeInputTransparentProperty.PropertyName)
 				UpdateNativeControl(); // poorly optimized
 		}
 
@@ -119,7 +119,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				if (layout.InputTransparent)
 				{
-					shouldInteract = !layout.InputTransparentInherited;
+					shouldInteract = !layout.CascadeInputTransparent;
 				}
 				else
 				{

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Layout.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Layout.xml
@@ -79,6 +79,37 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="CascadeInputTransparent">
+      <MemberSignature Language="C#" Value="public bool CascadeInputTransparent { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool CascadeInputTransparent" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CascadeInputTransparentProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty CascadeInputTransparentProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty CascadeInputTransparentProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Children">
       <MemberSignature Language="C#" Value="public System.Collections.Generic.IReadOnlyList&lt;Xamarin.Forms.Element&gt; Children { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.IReadOnlyList`1&lt;class Xamarin.Forms.Element&gt; Children" />
@@ -160,37 +191,6 @@
             </para>
         </remarks>
         <altmember cref="M:Xamarin.Forms.OnSizeRequest (double, double)" />
-      </Docs>
-    </Member>
-    <Member MemberName="InputTransparentInherited">
-      <MemberSignature Language="C#" Value="public bool InputTransparentInherited { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance bool InputTransparentInherited" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Boolean</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="InputTransparentInheritedProperty">
-      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty InputTransparentInheritedProperty;" />
-      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty InputTransparentInheritedProperty" />
-      <MemberType>Field</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InvalidateLayout">


### PR DESCRIPTION
Implements #1682.

### Description of Change ###

Add a PlatformSpecific property for `WebView` on UWP to allow WebViews to display alert boxes via JavaScript.

`webView.On<Windows>().SetIsJavaScriptAlertEnabled(true)` causes js calls to `window.alert` to display the intended message in a native UWP message box.

### API Changes ###

Added (UWP Only):
 - bool WebView.IsJavaScriptAlertEnabled() //Bindable Property
 - void WebView.SetIsJavaScriptAlertEnabled(bool value)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
