### PR TITLE
Feature/1678: Read-only entry and editor

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/EditorCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/EditorCoreGalleryPage.cs
@@ -35,7 +35,10 @@ namespace Xamarin.Forms.Controls
 			var textColorDisabledContainer = new ViewContainer<Editor> (Test.Editor.TextColor,
 				new Editor { Text = "I should have the default disabled text color", TextColor = Color.Red, IsEnabled = false });
 
-			Add (completedContainer);
+			var readOnlyContainer = new ViewContainer<Editor>(Test.Editor.IsReadOnly,
+				new Editor { Text = "This is read-only Editor", IsReadOnly = true });
+
+			Add(completedContainer);
 			Add (textContainer);
 			Add (textChangedContainer);
 			Add (textFontAttributesContainer);
@@ -46,6 +49,7 @@ namespace Xamarin.Forms.Controls
 			Add (textFontSizeLargeContainer);
 			Add (textColorContainer);
 			Add (textColorDisabledContainer);
+			Add (readOnlyContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/CoreGalleryPages/EntryCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/EntryCoreGalleryPage.cs
@@ -64,7 +64,10 @@ namespace Xamarin.Forms.Controls
 			var passwordColorContainer = new ViewContainer<Entry> (Test.Entry.PasswordColor,
 				new Entry { IsPassword = true, Text = "12345", TextColor = Color.Red });
 
-			Add (isPasswordContainer);
+			var readOnlyContainer = new ViewContainer<Entry>(Test.Entry.IsReadOnly,
+				new Entry { Text = "This is read-only Entry", IsReadOnly = true });
+
+			Add(isPasswordContainer);
 			Add (completedContainer);
 			Add (placeholderContainer);
 			Add (keyboardContainer);
@@ -87,6 +90,7 @@ namespace Xamarin.Forms.Controls
 			Add (textColorDisabledContainer);
 			Add (placeholderColorDisabledContainer);
 			Add (passwordColorContainer);
+			Add (readOnlyContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/NotifiedPropertiesTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/NotifiedPropertiesTests.cs
@@ -91,6 +91,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			new PropertyTestCase<Entry, string> ("Placeholder", v => v.Placeholder, (v, o) => v.Placeholder = o, () => null, "Foo"),
 			new PropertyTestCase<Entry, bool> ("IsPassword", v => v.IsPassword, (v, o) => v.IsPassword = o, () => false, true),
 			new PropertyTestCase<Entry, Color> ("TextColor", v => v.TextColor, (v, o) => v.TextColor = o, () => Color.Default, new Color (0, 1, 0)),
+			new PropertyTestCase<Entry, bool> ("IsReadOnly", v => v.IsReadOnly, (v, o) => v.IsReadOnly = o, () => true, false),
+			new PropertyTestCase<Editor, bool> ("IsReadOnly", v => v.IsReadOnly, (v, o) => v.IsReadOnly = o, () => true, false),
 			new PropertyTestCase<Frame, Color> ("BackgroundColor", v => v.BackgroundColor, (v, o) => v.BackgroundColor = o, () => Color.Default, new Color (0, 1, 0)),
 			new PropertyTestCase<Frame, Color> ("OutlineColor", v => v.OutlineColor, (v, o) => v.OutlineColor = o, () => Color.Default, new Color (0, 1, 0)),
 			new PropertyTestCase<Frame, bool> ("HasShadow", v => v.HasShadow, (v, o) => v.HasShadow = o, () => true, false),

--- a/Xamarin.Forms.Core/InputView.cs
+++ b/Xamarin.Forms.Core/InputView.cs
@@ -6,6 +6,8 @@ namespace Xamarin.Forms
 			coerceValue: (o, v) => (Keyboard)v ?? Keyboard.Default);
 		public static readonly BindableProperty IsSpellCheckEnabledProperty = BindableProperty.Create("IsSpellCheckEnabled", typeof(bool), typeof(InputView), true);
 
+		public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create(nameof(IsReadOnly), typeof(bool), typeof(InputView), false);
+
 		internal InputView()
 		{
 		}
@@ -20,6 +22,12 @@ namespace Xamarin.Forms
 		{
 			get { return (bool)GetValue(IsSpellCheckEnabledProperty); }
 			set { SetValue(IsSpellCheckEnabledProperty, value); }
+		}
+
+		public bool IsReadOnly
+		{
+			get { return (bool)GetValue(IsReadOnlyProperty); }
+			set { SetValue(IsReadOnlyProperty, value); }
 		}
 	}
 }

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -497,7 +497,8 @@ namespace Xamarin.Forms.CustomAttributes
 			TextColor,
 			FontAttributes,
 			FontFamily,
-			FontSize
+			FontSize,
+			IsReadOnly
 		}
 
 		public enum Entry
@@ -521,7 +522,8 @@ namespace Xamarin.Forms.CustomAttributes
 			PlaceholderColor,
 			TextDisabledColor,
 			PlaceholderDisabledColor,
-			PasswordColor
+			PasswordColor,
+			IsReadOnly
 		}
 
 		public enum Frame

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -82,6 +82,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateInputType();
 			UpdateTextColor();
 			UpdateFont();
+			UpdateIsReadOnly();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -100,6 +101,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateFont();
 			else if (e.PropertyName == Editor.FontSizeProperty.PropertyName)
 				UpdateFont();
+			else if (e.PropertyName == InputView.IsReadOnlyProperty.PropertyName)
+				UpdateIsReadOnly();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -186,6 +189,11 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			ElementController?.SendCompleted();
 			Control?.ClearFocus();
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.Focusable = !Element.IsReadOnly;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -97,6 +97,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateFont();
 			UpdatePlaceholderColor();
 			UpdateImeOptions();
+			UpdateIsReadOnly();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -157,6 +158,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateAlignment();
 			else if (e.PropertyName == PlatformConfiguration.AndroidSpecific.Entry.ImeOptionsProperty.PropertyName)
 				UpdateImeOptions();
+			else if (e.PropertyName == InputView.IsReadOnlyProperty.PropertyName)
+				UpdateIsReadOnly();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -228,6 +231,11 @@ namespace Xamarin.Forms.Platform.Android
 		void OnKeyboardBackPressed(object sender, EventArgs eventArgs)
 		{
 			Control?.ClearFocus();
-		}	
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.Focusable = !Element.IsReadOnly;
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EditorRenderer.cs
@@ -41,6 +41,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			UpdateFont();
 			UpdateTextColor();
 			UpdateEditable();
+			UpdateIsReadOnly();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -59,6 +60,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateFont();
 			else if (e.PropertyName == Editor.FontSizeProperty.PropertyName)
 				UpdateFont();
+			else if (e.PropertyName == Xamarin.Forms.InputView.IsReadOnlyProperty.PropertyName)
+				UpdateIsReadOnly();
 		}
 
 		protected override void SetBackgroundColor(Color color)
@@ -123,6 +126,11 @@ namespace Xamarin.Forms.Platform.MacOS
 			var textColor = Element.TextColor;
 
 			Control.TextColor = textColor.IsDefault ? NSColor.Black : textColor.ToNSColor();
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.Editable = !Element.IsReadOnly;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -59,6 +59,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateColor();
 				UpdateFont();
 				UpdateAlignment();
+				UpdateIsReadOnly();
 			}
 		}
 
@@ -88,6 +89,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateAlignment();
+			else if (e.PropertyName == Xamarin.Forms.InputView.IsReadOnlyProperty.PropertyName)
+				UpdateIsReadOnly();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -190,6 +193,11 @@ namespace Xamarin.Forms.Platform.MacOS
 			// ReSharper disable once RedundantCheckBeforeAssignment
 			if (Control.StringValue != Element.Text)
 				Control.StringValue = Element.Text ?? string.Empty;
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.Editable = !Element.IsReadOnly;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Editor.FontFamilyProperty, UpdateFontFamily);
 			RegisterPropertyHandler(Editor.FontAttributesProperty, UpdateFontAttributes);
 			RegisterPropertyHandler(Editor.KeyboardProperty, UpdateKeyboard);
+			RegisterPropertyHandler(Editor.IsReadOnlyProperty, UpdateIsReadOnly);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
@@ -114,6 +115,11 @@ namespace Xamarin.Forms.Platform.Tizen
 				return;
 
 			Control.Keyboard = Element.Keyboard.ToNative();
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.AllowFocus(!Element.IsReadOnly);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Entry.KeyboardProperty, UpdateKeyboard);
 			RegisterPropertyHandler(Entry.PlaceholderProperty, UpdatePlaceholder);
 			RegisterPropertyHandler(Entry.PlaceholderColorProperty, UpdatePlaceholderColor);
+			RegisterPropertyHandler(Entry.IsReadOnlyProperty, UpdateIsReadOnly);
 			if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable)
 			{
 				RegisterPropertyHandler("FontWeight", UpdateFontWeight);
@@ -128,6 +129,11 @@ namespace Xamarin.Forms.Platform.Tizen
 		void UpdateFontWeight()
 		{
 			Control.FontWeight = Specific.GetFontWeight(Element);
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.AllowFocus(!Element.IsReadOnly);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateTextAlignment();
 				UpdateFlowDirection();
 				UpdateDetectReadingOrderFromContent();
+				UpdateIsReadOnly();
 			}
 
 			base.OnElementChanged(e);
@@ -103,6 +104,10 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 			else if (e.PropertyName == Specifics.DetectReadingOrderFromContentProperty.PropertyName)
 				UpdateDetectReadingOrderFromContent();
+			else if (e.PropertyName == InputView.IsReadOnlyProperty.PropertyName)
+			{
+				UpdateIsReadOnly();
+			}
 		}
 
 		void OnLostFocus(object sender, RoutedEventArgs e)
@@ -231,6 +236,11 @@ namespace Xamarin.Forms.Platform.UWP
 					Control.TextReadingOrder = TextReadingOrder.UseFlowDirection;
 				}
 			}
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.IsReadOnly = Element.IsReadOnly;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateAlignment();
 				UpdatePlaceholderColor();
 				UpdateDetectReadingOrderFromContent();
+				UpdateIsReadOnly();
 			}
 		}
 
@@ -92,6 +93,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateAlignment();
 			else if (e.PropertyName == Specifics.DetectReadingOrderFromContentProperty.PropertyName)
 				UpdateDetectReadingOrderFromContent();
+			else if (e.PropertyName == InputView.IsReadOnlyProperty.PropertyName)
+				UpdateIsReadOnly();
 		}
 
 		protected override void UpdateBackgroundColor()
@@ -235,6 +238,11 @@ namespace Xamarin.Forms.Platform.UWP
 					Control.TextReadingOrder = TextReadingOrder.UseFlowDirection;
 				}
 			}
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.IsReadOnly = Element.IsReadOnly;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/EditorRenderer.cs
@@ -25,6 +25,7 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateInputScope();
 				UpdateTextColor();
 				UpdateFont();
+				UpdateIsReadOnly();
 			}
 
 			base.OnElementChanged(e);
@@ -47,6 +48,8 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateFont();
 			else if (e.PropertyName == Editor.FontSizeProperty.PropertyName)
 				UpdateFont();
+			else if (e.PropertyName == InputView.IsReadOnlyProperty.PropertyName)
+				UpdateIsReadOnly();
 		}
 		
 		void NativeOnTextChanged(object sender, System.Windows.Controls.TextChangedEventArgs textChangedEventArgs)
@@ -123,6 +126,11 @@ namespace Xamarin.Forms.Platform.WPF
 
 			_isDisposed = true;
 			base.Dispose(disposing);
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.IsReadOnly = Element.IsReadOnly;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateFont();
 				UpdateAlignment();
 				UpdatePlaceholderColor();
+				UpdateIsReadOnly();
 			}
 
 			base.OnElementChanged(e);
@@ -67,6 +68,8 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateAlignment();
 			else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
 				UpdatePlaceholderColor();
+			else if (e.PropertyName == InputView.IsReadOnlyProperty.PropertyName)
+				UpdateIsReadOnly();
 		}
 		
 		internal override void OnModelFocusChangeRequested(object sender, VisualElement.FocusRequestArgs args)
@@ -247,6 +250,11 @@ namespace Xamarin.Forms.Platform.WPF
 
 			_isDisposed = true;
 			base.Dispose(disposing);
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.IsReadOnly = Element.IsReadOnly;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateKeyboard();
 			UpdateEditable();
 			UpdateTextAlignment();
+			UpdateIsReadOnly();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -92,6 +93,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateFont();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateTextAlignment();
+			else if (e.PropertyName == Xamarin.Forms.InputView.IsReadOnlyProperty.PropertyName)
+				UpdateIsReadOnly();
 		}
 
 		void HandleChanged(object sender, EventArgs e)
@@ -160,6 +163,11 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.TextColor = UIColor.Black;
 			else
 				Control.TextColor = textColor.ToUIColor();
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.UserInteractionEnabled = !Element.IsReadOnly;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -104,6 +104,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateKeyboard();
 			UpdateAlignment();
 			UpdateAdjustsFontSizeToFitWidth();
+			UpdateIsReadOnly();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -137,6 +138,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateAdjustsFontSizeToFitWidth();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateAlignment();
+			else if (e.PropertyName == Xamarin.Forms.InputView.IsReadOnlyProperty.PropertyName)
+				UpdateIsReadOnly();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -257,6 +260,11 @@ namespace Xamarin.Forms.Platform.iOS
 			// ReSharper disable once RedundantCheckBeforeAssignment
 			if (Control.Text != Element.Text)
 				Control.Text = Element.Text;
+		}
+
+		void UpdateIsReadOnly()
+		{
+			Control.UserInteractionEnabled = !Element.IsReadOnly;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This PR adds the `IsReadOnly` bindable property to the `InputView ` i.e.`Editor `and `Entry` controls. Default value is `false` so this change and usage of this property is backwards compatible.

### Bugs Fixed ###

[[Enhancement] Entry: Read-only entry #1678](https://github.com/xamarin/Xamarin.Forms/issues/1678)

### API Changes ###

Added:
 - `BindableProperty InputView.IsReadOnlyProperty;`
 

Changed:
 - None

### Behavioral Changes ###
- None

### Supported Platforms ###

- [x] iOS
- [x] Android
- [x] UWP
- [x] Tizen
- [x] WPF
- [x] macOS
- [ ] GTK (I am researching about it, hope I will implement it soon)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

### Remark ###
There was a section "Implications for CSS", can I get more info about that, is there any way for me to implement that also.